### PR TITLE
SOC-3457 | Ajustar comportamento drag and drop

### DIFF
--- a/addon/components/file-dropzone/component.js
+++ b/addon/components/file-dropzone/component.js
@@ -239,7 +239,7 @@ export default BaseComponent.extend({
       if (get(this, 'isDestroyed')) {
         return;
       }
-      set(this, 'active', false);
+      this._deactivateWithDebounce();
     }
   },
 
@@ -247,6 +247,13 @@ export default BaseComponent.extend({
     set(this[DATA_TRANSFER], 'dataTransfer', evt.dataTransfer);
     if (this.isAllowed()) {
       evt.dataTransfer.dropEffect = get(this, 'cursor');
+      
+      if (this.get('active')) {
+        if (this._deactivateTimer) {
+          clearTimeout(this._deactivateTimer);
+          this._deactivateTimer = null;
+        }
+      }
     }
   },
 
@@ -323,5 +330,20 @@ export default BaseComponent.extend({
     set(this, 'active', false);
     get(this, 'queue')._addFiles(get(this[DATA_TRANSFER], 'files'), 'drag-and-drop');
     this[DATA_TRANSFER] = null;
+  },
+
+  _deactivateWithDebounce() {
+    this._clearDeactivateTimer();    
+    this._deactivateTimer = setTimeout(() => {
+      set(this, 'active', false);
+      this._deactivateTimer = null;
+    }, 100);
+  },
+
+  _clearDeactivateTimer() {
+    if (this._deactivateTimer) {
+      clearTimeout(this._deactivateTimer);
+      this._deactivateTimer = null;
+    }
   }
 });

--- a/addon/file.js
+++ b/addon/file.js
@@ -131,7 +131,7 @@ export default EmberObject.extend({
     Object.defineProperty(this, 'id', {
       writeable: false,
       enumerable: true,
-      value: `file-${uuid()}`
+      value: uuid()
     });
   },
 


### PR DESCRIPTION
## Motivação (dê preferência à uma explicação não técnica)

Aplicado melhoria para controlar os eventos disparados ao longo do `drag and drop` no agendamento.

## Solução proposta (incluindo detalhes técnicos e suas motivações)

- Aplicado um debounce para o evento de `dragleave`, para que a alternância de estado não seja a todo momento.
- O timeout é limpo enquanto o evento de `dragover` estiver ativo

|Antes|Depois|
|---|---|
|https://github.com/user-attachments/assets/72c68885-2541-474c-99f7-09674ae3d588 |https://github.com/user-attachments/assets/2f8f40f4-304e-46a8-b51b-3d4aa6aa4896|



## Comentário

Algumas explicações:

- este projeto é um fork, ele foi forkeado e criado uma tag `2.5.3`; porém após isto existiu um update no projeto com tags vindas do projeto original, ficando a frente da `2.5.3`. A versão mais alta que tem no nosso fork é a `3.0.3`. Este PR está apontando para esta versão mais recente, na master, no nosso fork. Assim vamos atualizar também esta versão para uma mais atual, e é **importante testarmos bem a lib para validar que o processo de uploader esteja funcionando corretamente, tanto com drag and drop, como indo pela galeria selecionando os arquivos.**
- fiz o teste localmente com o comando de build que rodamos em produção para garantir que o projeto continue funcionando e que não tenhamos surpresas ao tentar buildar o mesmo para produção (são processos diferentes):
<img width="941" height="305" alt="image" src="https://github.com/user-attachments/assets/b5e172dc-2720-4962-85cf-b75f9955e2e1" />

- [esta alteração](https://github.com/mlabssoftware/ember-file-upload/pull/1/files#diff-7f084a455765f8c7b6b32c5bc2fec0824ac48284e0c7fbf64be4bc70824c9795L134), e única, foi feita pelo @marciomoradei na tag 2.5.3, trouxe para cá para garantir que o projeto se man tenha atualizado nesta versão mais recente.

Para validar que a implementação acima continua funcionando neste PR basta validar o payload mandando no `ingest`:
|Sem a implementação | Com a implementação|
|---|---|
|<img width="507" height="247" alt="image" src="https://github.com/user-attachments/assets/65b2add6-e371-47fc-892e-f662061ef714" />|<img width="507" height="247" alt="image" src="https://github.com/user-attachments/assets/415aed4a-663f-4963-bdca-969657eddff1" />|

O pré-fixo `file` não deve ser passado.

## Como testar

| Projeto       | Branch      |
|:-------------:|:-----------:|
| ember-file-upload         | SOC-3457       |

### Critérios de aceitação

* [ ] Critério 1
  - **Dado**  que esteja arrastando um ou mais arquivos
  - **Quando** colocado o mouse com os arquivos na área de interesse e sair da área
  - **Então** o drag over deve funcionar normalmente, sem oscilações como as que estão acontecendo em produção.

## Links

[Link da Issue](https://socialmlabs.atlassian.net/browse/SOC-3457)

### Revisores

@mlabssoftware/social
